### PR TITLE
Update documents.py

### DIFF
--- a/core/documents.py
+++ b/core/documents.py
@@ -186,7 +186,7 @@ class Patent (Document):
 	@property
 	def cpcs(self):
 		biblio = db.get_patent_data(self.id, True)
-		return biblio['cpcs']
+		return biblio.get("cpcs", [])
 
 	@property
 	def independent_claims(self):


### PR DESCRIPTION
changes for solving issue "In core/documents.py line 189, the current implementation assumes that every patent document has the key cpcs - it's not true for some (edge case) documents in the database.

For such documents, an empty list could be returned by updating line 189 to biblio.get("cpcs", [])."